### PR TITLE
FE-58 ✨ 검색페이지 UI 작업

### DIFF
--- a/src/pages/search/RecentSearches.tsx
+++ b/src/pages/search/RecentSearches.tsx
@@ -1,0 +1,43 @@
+import { useState, useEffect } from 'react';
+import { Button } from '@mantine/core';
+
+const RecentSearches = ({ onSearch, searches }: { onSearch: (term: string) => void; searches: string[] }) => {
+  const [recentSearches, setRecentSearches] = useState<string[]>(searches);
+
+  //NOTE : "searches" prop가 변경될 때마다 recentSearches 상태를 업데이트해서 최근 검색어 목록이 업데이트될 때 UI에 반영됨.
+  useEffect(() => {
+    setRecentSearches(searches);
+  }, [searches]);
+
+  const handleSearchClick = (term: string) => {
+    onSearch(term);
+  };
+
+  //'모두 지우기' 버튼을 클릭할 때 로컬 스토리지에서 recentSearches 항목(최신 검색어 목록)을 삭제됨.
+  const clearSearches = () => {
+    localStorage.removeItem('recentSearches');
+    setRecentSearches([]);
+  };
+
+  return (
+    <div className='flex flex-col tablet:w-[384px] w-[312px] desktop:w-[640px] gap-4'>
+      <div className='flex items-center justify-between text-black-700'>
+        <p className='text-base font-medium tablet:text-xl desktop:text-2xl'>최근 검색어</p>
+        <Button onClick={clearSearches} className='text-xs font-semibold bg-white tablet:text-sm text-state-alert hover:bg-white hover:text-state-alert hover:underline desktop:text-base'>
+          모두 지우기
+        </Button>
+      </div>
+      <div className='flex flex-wrap justify-start gap-2'>
+        {recentSearches.map((search, index) => (
+          <div key={index} className='w-auto h-auto px-3 py-2 bg-background rounded-[18px] text-black-300'>
+            <button onClick={() => handleSearchClick(search)} className='text-left'>
+              {search}
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default RecentSearches;

--- a/src/pages/search/SearchCard.tsx
+++ b/src/pages/search/SearchCard.tsx
@@ -29,7 +29,7 @@ const highlight = (text: string, searchTerm: string) => {
 
 const SearchCard: React.FC<CardProps> = ({ content, author, tags, searchTerm }) => {
   return (
-    <div className='tablet:w-[384px] bg-white text-base font-normal border-b-1 desktop:text-xl border-b border-gray-100 min-w-[360px] desktop:w-[640px] px-[24px] py-[16px] gap-2 desktop:py-[24px] desktop:gap-4'>
+    <div className='tablet:w-[384px] bg-white text-base font-normal border-b-1 desktop:text-xl border-b border-gray-100 min-w-[360px] w-[360px] desktop:w-[640px] px-[24px] py-[16px] gap-2 desktop:py-[24px] desktop:gap-4'>
       <div className='flex flex-col gap-1 text-black-600 font-paraph tablet:gap-2 desktop:gap-6'>
         <p>{highlight(content, searchTerm)}</p>
         <p className='text-blue-400'>- {highlight(author, searchTerm)} -</p>

--- a/src/pages/search/SearchCard.tsx
+++ b/src/pages/search/SearchCard.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+interface Tag {
+  id: number;
+  name: string;
+}
+
+interface CardProps {
+  content: string;
+  author: string;
+  tags: Tag[];
+  searchTerm: string;
+}
+
+//NOTE : 각 에피그램에서 사용자가 입력한 단어를 파란색으로 강조하기 위한 함수
+const highlight = (text: string, searchTerm: string) => {
+  if (!searchTerm) return text;
+  const parts = text.split(new RegExp(`(${searchTerm})`, 'gi'));
+  return parts.map((part, index) =>
+    part.toLowerCase() === searchTerm.toLowerCase() ? (
+      <span key={index} style={{ color: '#5195EE' }}>
+        {part}
+      </span>
+    ) : (
+      part
+    ),
+  );
+};
+
+const SearchCard: React.FC<CardProps> = ({ content, author, tags, searchTerm }) => {
+  return (
+    <div className='tablet:w-[384px] bg-white text-base font-normal border-b-1 desktop:text-xl border-b border-gray-100 min-w-[360px] desktop:w-[640px] px-[24px] py-[16px] gap-2 desktop:py-[24px] desktop:gap-4'>
+      <div className='flex flex-col gap-1 text-black-600 font-paraph tablet:gap-2 desktop:gap-6'>
+        <p>{highlight(content, searchTerm)}</p>
+        <p className='text-blue-400'>- {highlight(author, searchTerm)} -</p>
+      </div>
+
+      <div className='flex justify-end space-x-[12px] text-blue-400 '>
+        {tags.map((tag) => (
+          <span key={tag.id}>{highlight(tag.name, searchTerm)}</span>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SearchCard;

--- a/src/pages/search/data.ts
+++ b/src/pages/search/data.ts
@@ -1,0 +1,193 @@
+// data.ts
+export const data = {
+  list: [
+    {
+      likeCount: 0,
+      id: 240,
+      content: '커피이란 우리를 내적인 행복으로 이끄는 태그의 손길이다.',
+      author: '클라우스 랑에',
+      referenceTitle: '클라우스 랑에란',
+      referenceUrl: 'https://namu.wiki/w/%EC%95%99%EB%93%9C%EB%A0%88%20%EB%A7%90%EB%A1%9C',
+      writerId: 110,
+      tags: [
+        {
+          id: 139,
+          name: '#짧은명언',
+        },
+        {
+          id: 140,
+          name: '#우울증',
+        },
+      ],
+    },
+    {
+      likeCount: 0,
+      id: 239,
+      content: '커피이란 우리를 내적인 행복으로 이끄는 유혹의 손길이다.',
+      author: '클라우스 랑에',
+      referenceTitle: '클라우스 랑에란',
+      referenceUrl: 'https://namu.wiki/w/%EC%95%99%EB%93%9C%EB%A0%88%20%EB%A7%90%EB%A1%9C',
+      writerId: 110,
+      tags: [
+        {
+          id: 137,
+          name: '짧은명언',
+        },
+        {
+          id: 138,
+          name: '우울증',
+        },
+      ],
+    },
+    {
+      likeCount: 0,
+      id: 238,
+      content: '우울증이란 우리를 내적인 나락으로 이끄는 유혹의 손길이다.',
+      author: '클라우스 랑에',
+      referenceTitle: '클라우스 랑에란',
+      referenceUrl: 'https://namu.wiki/w/%EC%95%99%EB%93%9C%EB%A0%88%20%EB%A7%90%EB%A1%9C',
+      writerId: 110,
+      tags: [
+        {
+          id: 137,
+          name: '짧은명언',
+        },
+        {
+          id: 138,
+          name: '우울증',
+        },
+      ],
+    },
+    {
+      likeCount: 0,
+      id: 237,
+      content: '우울증이란 우리를 내적인 나락으로 이끄는 유혹의 손길이다.',
+      author: '클라우스 랑에',
+      referenceTitle: '클라우스 랑에란',
+      referenceUrl: 'https://namu.wiki/w/%EC%95%99%EB%93%9C%EB%A0%88%20%EB%A7%90%EB%A1%9C',
+      writerId: 110,
+      tags: [
+        {
+          id: 137,
+          name: '짧은명언',
+        },
+        {
+          id: 138,
+          name: '우울증',
+        },
+      ],
+    },
+    {
+      likeCount: 0,
+      id: 236,
+      content: '이 세상에는 위대한 진실이 하나 있어. 무언가를 온 마음을 다해 원한다면, 반드시 그렇게 된다는 거야.',
+      author: '파우울로 코엘료',
+      referenceTitle: '앙드레 말로란',
+      referenceUrl: 'https://namu.wiki/w/%EC%95%99%EB%93%9C%EB%A0%88%20%EB%A7%90%EB%A1%9C',
+      writerId: 110,
+      tags: [
+        {
+          id: 136,
+          name: '새로운영감',
+        },
+      ],
+    },
+    {
+      likeCount: 0,
+      id: 235,
+      content: '오랫동안 꿈을 그리는 사람은 마침내 그 꿈을 닮아 간다.',
+      author: '앙드레 말로',
+      referenceTitle: '앙드레 말로란',
+      referenceUrl: 'https://namu.wiki/w/%EC%95%99%EB%93%9C%EB%A0%88%20%EB%A7%90%EB%A1%9C',
+      writerId: 110,
+      tags: [
+        {
+          id: 114,
+          name: '나아가야할때',
+        },
+        {
+          id: 115,
+          name: '꿈을이루고싶을때',
+        },
+      ],
+    },
+    {
+      likeCount: 0,
+      id: 201,
+      content: '에피그램 내용입니다.',
+      author: '저자',
+      referenceTitle: '네이버',
+      referenceUrl: 'https://www.naver.com/',
+      writerId: 152,
+      tags: [
+        {
+          id: 91,
+          name: 'tag1',
+        },
+        {
+          id: 92,
+          name: 'tag2',
+        },
+      ],
+    },
+    {
+      likeCount: 0,
+      id: 200,
+      content: '에피그램 내용입니다.',
+      author: '저자',
+      referenceTitle: '네이버',
+      referenceUrl: 'https://www.naver.com/',
+      writerId: 152,
+      tags: [
+        {
+          id: 91,
+          name: 'tag1',
+        },
+        {
+          id: 92,
+          name: 'tag2',
+        },
+      ],
+    },
+    {
+      likeCount: 0,
+      id: 199,
+      content: '에피그램 내용입니다.',
+      author: '저자',
+      referenceTitle: '네이버',
+      referenceUrl: 'https://www.naver.com/',
+      writerId: 152,
+      tags: [
+        {
+          id: 91,
+          name: 'tag1',
+        },
+        {
+          id: 92,
+          name: 'tag2',
+        },
+      ],
+    },
+    {
+      likeCount: 0,
+      id: 198,
+      content: '에피그램 내용입니다.',
+      author: '저자',
+      referenceTitle: '네이버',
+      referenceUrl: 'https://www.naver.com/',
+      writerId: 152,
+      tags: [
+        {
+          id: 91,
+          name: 'tag1',
+        },
+        {
+          id: 92,
+          name: 'tag2',
+        },
+      ],
+    },
+  ],
+  nextCursor: 198,
+  totalCount: 19,
+};

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,3 +1,109 @@
-export default function Search() {
-  return <div>여기는 검색 페이지입니다.</div>;
-}
+import { useState, useEffect } from 'react';
+import { TextInput, CloseButton } from '@mantine/core';
+import { IconSearch } from '@tabler/icons-react';
+import { useDebouncedValue } from '@mantine/hooks';
+import { useLocation, useNavigate } from 'react-router-dom';
+import SearchCard from './SearchCard';
+import RecentSearches from './RecentSearches';
+import { data } from './data'; //데이터더미
+
+const Search = () => {
+  const SearchIcon = <IconSearch style={{ width: '20px', height: '20px' }} />;
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const [value, setValue] = useState('');
+  const [debounced] = useDebouncedValue(value, 200);
+  const [filteredData, setFilteredData] = useState(data.list);
+  const [recentSearches, setRecentSearches] = useState<string[]>([]);
+
+  //NOTE : URL 쿼리 파라미터에서 검색어 읽기 위한 useEffect로 컴포넌트가 렌더링될 때마다 location.search가 변경되면 실행됨.
+  useEffect(() => {
+    const queryParams = new URLSearchParams(location.search);
+    const query = queryParams.get('query') || '';
+    setValue(query);
+  }, [location.search]);
+
+  //NOTE : 로컬 스토리지에서 최근 검색어 읽기 위한 useEffect
+  useEffect(() => {
+    const searches = JSON.parse(localStorage.getItem('recentSearches') || '[]');
+    setRecentSearches(searches);
+  }, []);
+
+  //FIX : 검색어에 따른 필터링 및 URL 업데이트인 useEffect인데 API에 검색 키워드 파라미터가 있어서 연동할때 수정예정.
+  useEffect(() => {
+    if (debounced.trim() === '') {
+      setFilteredData([]);
+    } else {
+      const filtered = data.list.filter((item) => {
+        const contentMatch = item.content.includes(debounced);
+        const authorMatch = item.author.includes(debounced);
+        const tagsMatch = item.tags.some((tag) => tag.name.includes(debounced));
+        return contentMatch || authorMatch || tagsMatch;
+      });
+      setFilteredData(filtered);
+    }
+
+    //저장 URL에 검색어 저장
+    if (debounced.trim() !== '') {
+      navigate(`?query=${encodeURIComponent(debounced)}`, { replace: true });
+    } else {
+      navigate('/search', { replace: true });
+    }
+  }, [debounced, navigate]);
+
+  //검색어 핸들링 함수
+  const handleSearch = (term: string) => {
+    setValue(term);
+    if (term.trim() === '') return;
+
+    const searches = JSON.parse(localStorage.getItem('recentSearches') || '[]');
+    if (!searches.includes(term)) {
+      searches.push(term);
+      localStorage.setItem('recentSearches', JSON.stringify(searches));
+      setRecentSearches([...searches]);
+    }
+
+    //검색어를 URL에 저장
+    navigate(`?query=${encodeURIComponent(term)}`);
+  };
+
+  return (
+    <div className='h-screen bg-white'>
+      <div className='flex flex-col items-center justify-center gap-6 tablet:gap-8 desktop:gap-10'>
+        <TextInput
+          placeholder='검색어를 입력하세요.'
+          leftSection={SearchIcon}
+          value={value}
+          radius='md'
+          size='md'
+          onChange={(event) => setValue(event.currentTarget.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              handleSearch(value);
+            }
+          }}
+          classNames={{
+            root: 'm-5 tablet:w-[384px] min-w-[312px] desktop:w-[640px]',
+            input: 'rounded-none border-0 border-b-2 border-blue-800 text-base font-normal h-[52px] tablet:h-[60px] desktop:h-[80px] tablet:text-xl desktop:text-2xl desktop:border-b-4',
+          }}
+          rightSection={<CloseButton aria-label='Clear input' onClick={() => setValue('')} style={{ display: value ? undefined : 'none' }} />}
+        />
+
+        {recentSearches.length > 0 && <RecentSearches onSearch={handleSearch} searches={recentSearches} />}
+
+        <div className='flex flex-col items-center justify-center'>
+          {debounced.trim() === '' ? (
+            <p className='font-medium text-blue-800'>검색어를 입력해주세요.</p>
+          ) : filteredData.length > 0 ? (
+            filteredData.map((item) => <SearchCard key={item.id} content={item.content} author={item.author} tags={item.tags} searchTerm={debounced} />)
+          ) : (
+            <p className='font-medium text-blue-800'>검색 결과가 없습니다.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Search;

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -69,7 +69,7 @@ const Search = () => {
   };
 
   return (
-    <div className='h-screen bg-white'>
+    <div className='h-full min-h-screen bg-white pb-[20px]'>
       <div className='flex flex-col items-center justify-center gap-6 tablet:gap-8 desktop:gap-10'>
         <TextInput
           placeholder='검색어를 입력하세요.'


### PR DESCRIPTION
## :bookmark: Issue Ticket
<!-- Issue Ticket이 있을 경우, 해당 링크를 연결해주세요 -->
[FE-58](https://ohbread-210713.atlassian.net/browse/FE-58)

## :writing_hand: Description
<!-- 어떤 내용의 PR인지 간단하게 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
에피그램를 검색할 수 있는 페이지인 검색 페이지 UI 구현했습니다.
지금은 일단 API 연결 전 가짜 더미로 작동되게 구현해서 어떻게 작동되는지 궁금하신 분은 해보시고 수정사항 있으면 이야기해주세요:) 

### [변경사항]
#### 1. 검색어 입력하는 폼을 사용자가 사용하기 편하게 수정했습니다...별로면 원래 피그마대로 변경하겠습니다
[피그마 시연]
<img width="311" alt="image" src="https://github.com/user-attachments/assets/3e0842fd-c544-4e64-87bb-1a07309bf4be">

[수정한 버전]
검색어 입력전
<img width="181" alt="image" src="https://github.com/user-attachments/assets/09070ea5-31fd-47a4-bc55-0454f0b63adf">
검색어 입력후
<img width="181" alt="image" src="https://github.com/user-attachments/assets/47d34613-2f8a-4eba-aac0-f4768e2f543c">

#### 2. 아직 태그 공통 컴포넌트가 구현되기 전이라서 제가 그냥 태그는 만들었는데 나중에 태그 공통 컴포넌트가 구현완료되면 가져다가 수정하겠습니다. 이와 마찬가지로 원래 태그 한개씩 삭제가능하게 구현하자고 이야기가 나온거로 알고 있는데 이 부분도 나중에  같이 수정하겠습니다. 


## :white_check_mark: Checklist
### PR
<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->
- [x] Branch Convention 확인
> `epic/` 에픽, `feat/` 피쳐, `fix/` 버그 수정, `refactor/` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test
- [x] 로컬 작동 확인

[검색페이지 반응형 확인]
![반응형-검색페이지-Clipchamp로-제작](https://github.com/user-attachments/assets/a307deaa-1fbe-47f6-ac03-0efb2c6cbe0d)

[가짜 더미로 작동하는 검색페이지]
![검색페이지-작동-Clipchamp로-제작](https://github.com/user-attachments/assets/58272513-64ef-4dbd-8967-e62e264f7b59)


### Additional Notes
<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->
- [x] 결과 에피그램 아이템을 클릭하면 해당 에피그램 상세 페이지 로 이동하는 부분은 API 연동하면서 구현할 예정
- [x] 에피그램 관련해서 Pagination 개념을 응용하여 무한 스크롤 구현하는 부분도 API API 연동하면서 구현할 예정
- 그리고 중요한 내용인!! 에피그램 작성 페이지에서 태그 저장할때 #를 넣어서 저장해야 검색어에 #붙여서 검색할 떄 검색결과가 잘 나올것 같습니다!!


[FE-58]: https://ohbread-210713.atlassian.net/browse/FE-58?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ